### PR TITLE
Make possible to get hold of subscription before a message is recieved

### DIFF
--- a/lib/channel.js
+++ b/lib/channel.js
@@ -235,7 +235,7 @@ Channel.prototype.send = function(headers, body, callback) {
   return this;
 };
 
-Channel.prototype.subscribe = function(headers, onMessageCallback) {
+Channel.prototype.subscribe = function(headers, onMessageCallback, onSubscribeCallback) {
   
   var completionCallback = function(){};
   var unsubscribe = function(){};
@@ -250,6 +250,8 @@ Channel.prototype.subscribe = function(headers, onMessageCallback) {
     cancel: cancel,
     unsubscribe: cancel
   };
+
+  onSubscribeCallback && onSubscribeCallback(channelSubscription);
   
   this._transmit(function(error, client, complete) {
     


### PR DESCRIPTION
so that you can 'refresh' the subscription now and then, incase it gets deleted - in case of virtual topic and possibly to deal with stale connections.