### PR TITLE
Make header encoding version specific

### DIFF
--- a/lib/OutgoingFrameStream.js
+++ b/lib/OutgoingFrameStream.js
@@ -25,7 +25,43 @@ function OutgoingFrameStream(destination) {
   
   this._frame = null;
   this._queue = [];
+
+  this.setVersion('1.0');
 }
+
+OutgoingFrameStream.prototype.setVersion = function(versionId) {
+
+  var v10Encode = createEncodeFunction([]);
+
+  var v11Encode = createEncodeFunction([
+    [/\\/g, '\\\\'],
+    [/\n/g, '\\n'],
+    [/:/g, '\\c']
+  ]);
+
+  var v12Encode = createEncodeFunction([
+    [/\\/g, '\\\\'],
+    [/\r/g, '\\r'],
+    [/\n/g, '\\n'],
+    [/:/g, '\\c']
+  ]);
+
+  var encoders = {
+    '1.0': v10Encode,
+    '1.1': v11Encode,
+    '1.2': v12Encode
+  };
+
+  var encoder = encoders[versionId];
+
+  if (typeof encoder === 'undefined') {
+    return false;
+  }
+
+  this._encode = encoder;
+
+  return true;
+};
 
 OutgoingFrameStream.prototype._queueFrame = function(frame) {
   
@@ -130,14 +166,15 @@ Frame.prototype._writeHeaderAndBody = function(chunk, encoding, cb) {
 
 Frame.prototype._writeHeader = function(cb) {
   
-  var header = encode(this.command) + '\n';
+  var header = this._stream._encode(this.command) + '\n';
   
   for (var key in this.headers) {
     
     var value = this.headers[key];
     
     if (value !== null && value !== undefined) {
-      header += encode(key) + ':' + encode(value) + '\n';
+      header += this._stream._encode(key) + ':' +
+        this._stream._encode(value) + '\n';
     }
   }
   
@@ -226,15 +263,16 @@ function dequeue(stream) {
   service(stream);
 }
 
-function encode(value) {
-  
-  value = '' + value;
-  
-  value = value.replace('\\', '\\\\');
-  value = value.replace('\n', '\\n');
-  value = value.replace(':', '\\c');
-  
-  return value;
+function createEncodeFunction(escapeSequences) {
+  return function(value) {
+    value = '' + value;
+
+    for (var i = 0; i < escapeSequences.length; i++) {
+      value = value.replace(escapeSequences[i][0], escapeSequences[i][1]);
+    }
+
+    return value;
+  };
 }
 
 function errorOnWrite(chunk, encoding, cb) {

--- a/lib/Socket.js
+++ b/lib/Socket.js
@@ -152,6 +152,7 @@ Socket.prototype.hasFinishedOutput = function() {
 
 Socket.prototype.setVersion = function(version) {
   this._incoming.setVersion(version);
+  this._output.setVersion(version);
 };
 
 Socket.prototype.getTransportSocket = function() {

--- a/test/OutgoingFrameStream.js
+++ b/test/OutgoingFrameStream.js
@@ -19,6 +19,7 @@ describe('OutgoingFrameStream', function(){
         dest = new Buffer(256);
         writable = new BufferWritable(dest);
         output = new OutgoingFrameStream(writable);
+        output.setVersion('1.1');
     });
     
     describe('#frame', function(){


### PR DESCRIPTION
Previously encoding was always done according to 1.1 rules.

Also, this fixes encoding of multiple chars per header. Previously only
the first of e.g. multiple colons was encoded per value, not all of
them.