### PR TITLE
Set error.connectArgs on failover connection errors

### DIFF
--- a/lib/ConnectFailover.js
+++ b/lib/ConnectFailover.js
@@ -211,6 +211,7 @@ ConnectFailover.prototype.connect = function(callback) {
       if (error) {
         
         if (self.listeners('error').length > 0) {
+          error.connectArgs = server.serverProperties.connectOptions;
           self.emit('error', error, server);
         }
         


### PR DESCRIPTION
For example the failover examples' error handlers expect to find it e.g. in case of login error, not only if connection fails.