### PR TITLE
Add Client#sendMessage method

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -174,7 +174,7 @@ Client.prototype.send = function(headers, options) {
 /*
  * Send a message with the specified body to the server.
  */
-Client.prototype.sendMessage = function(body, headers, options) {
+Client.prototype.sendString = function(body, headers, options) {
   var frame = this.send(headers, options);
   frame.write(body);
   frame.end();

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -171,6 +171,15 @@ Client.prototype.send = function(headers, options) {
   return this.sendFrame('SEND', headers, options);
 };
 
+/*
+ * Send a message with the specified body to the server.
+ */
+Client.prototype.sendMessage = function(body, headers, options) {
+  var frame = this.send(headers, options);
+  frame.write(body);
+  frame.end();
+};
+
 Client.prototype.begin = function(headers) {
   
   if (typeof headers !== 'object') {

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -174,7 +174,7 @@ Client.prototype.send = function(headers, options) {
 /*
  * Send a message with the specified body to the server.
  */
-Client.prototype.sendString = function(body, headers, options) {
+Client.prototype.sendString = function(headers, body, options) {
   var frame = this.send(headers, options);
   frame.write(body);
   frame.end();

--- a/test/Client.js
+++ b/test/Client.js
@@ -193,7 +193,7 @@ describe('Client', function() {
         });
     });
 
-    describe('#sendMessage', function() {
+    describe('#sendString', function() {
         it('should send a message with the specified body', function(done) {
             server._send = function(frame, beforeSendResponse) {
                 assert(frame.headers.destination === '/test');
@@ -208,7 +208,7 @@ describe('Client', function() {
             };
 
             client.connect('localhost', function() {
-                client.sendMessage('abcdefgh', {destination: '/test'});
+                client.sendString('abcdefgh', {destination: '/test'});
             });
         });
 
@@ -225,7 +225,7 @@ describe('Client', function() {
             };
 
             client.connect('localhost', function() {
-                client.sendMessage('abcdefgh', '/test');
+                client.sendString('abcdefgh', '/test');
             });
         });
     });

--- a/test/Client.js
+++ b/test/Client.js
@@ -192,7 +192,44 @@ describe('Client', function() {
             });
         });
     });
-    
+
+    describe('#sendMessage', function() {
+        it('should send a message with the specified body', function(done) {
+            server._send = function(frame, beforeSendResponse) {
+                assert(frame.headers.destination === '/test');
+                var writable = new BufferWritable(new Buffer(26));
+                frame.on('end', function() {
+                    beforeSendResponse();
+                    assert(writable.getWrittenSlice().toString() === 'abcdefgh');
+                    done();
+                });
+
+                frame.pipe(writable);
+            };
+
+            client.connect('localhost', function() {
+                client.sendMessage('abcdefgh', {destination: '/test'});
+            });
+        });
+
+        it('should treat the second argument as the destination if it\'s a string value', function(done) {
+            server._send = function(frame, beforeSendResponse) {
+                assert(frame.headers.destination === '/test');
+                var writable = new BufferWritable(new Buffer(26));
+                frame.on('end', function() {
+                    beforeSendResponse();
+                    done();
+                });
+
+                frame.pipe(writable);
+            };
+
+            client.connect('localhost', function() {
+                client.sendMessage('abcdefgh', '/test');
+            });
+        });
+    });
+
     describe('#destroy', function() {
         
         it('should emit an error event with the passed error argument', function(done) {

--- a/test/Client.js
+++ b/test/Client.js
@@ -208,7 +208,7 @@ describe('Client', function() {
             };
 
             client.connect('localhost', function() {
-                client.sendString('abcdefgh', {destination: '/test'});
+                client.sendString({destination: '/test'}, 'abcdefgh');
             });
         });
 
@@ -225,7 +225,7 @@ describe('Client', function() {
             };
 
             client.connect('localhost', function() {
-                client.sendString('abcdefgh', '/test');
+                client.sendString('/test', 'abcdefgh');
             });
         });
     });


### PR DESCRIPTION
I've added `Client#sendMessage` method which encapsulates working with `frame` stream when a message is sent. I do so because in a big project there are too many duplicated code like:

```js
var frame = client.send(headers);
frame.write('something');
frame.end();
```

Yes, I know that I can write something like:

```js
client.send(headers).end('something');
```

but it makes the code harder to read.