### PR TITLE
message.ack, rather than client.ack(message); as per the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ stompit.connect(connectOptions, function(error, client) {
       
       console.log('received message: ' + body);
       
-      client.ack(message);
+      message.ack();
       
       client.disconnect();
     });


### PR DESCRIPTION
References #44