### PR TITLE
#27 - 'connection timed out' error with activeMQ broker and heartbeat

### DIFF
--- a/docs/sources/api/connect.md
+++ b/docs/sources/api/connect.md
@@ -23,6 +23,8 @@ Options:
 * `path` `string` use unix domain socket and use path as the destination address
 * `ssl` `boolean` `Default:false` use secure connection
 * `connect` `function` override the transport factory constructor used
+* `heartbeatDelayMargin` `integer` `Default:100` add milliseconds for server heart-beat wait interval
+* `heartbeatOutputMargin` `integer` `Default:0` substract milliseconds for client heart-beat start interval
 
 Options available when ssl is set to true:
 

--- a/lib/Socket.js
+++ b/lib/Socket.js
@@ -60,6 +60,7 @@ function Socket(transportSocket, options) {
   
   this._heartbeat = options.heartbeat || [0, 0];
   this._heartbeatDelayMargin = options.heartbeatDelayMargin || 100;
+  this._heartbeatOutputMargin = options.heartbeatOutputMargin || 0;
   
   var readFrameBody = function(frame, callback) {
     
@@ -193,7 +194,7 @@ Socket.prototype.setHeartbeat = function(heartbeat) {
 Socket.prototype._runHeartbeat = function(output, input) {
   
   output = output === 0 || this._heartbeat[0] === 0 ? 
-    0 : Math.max(output, this._heartbeat[0]);
+    0 : Math.max(output, this._heartbeat[0]) - this._heartbeatOutputMargin;
   
   input = input === 0 || this._heartbeat[1] === 0 ? 
     0 : Math.max(input, this._heartbeat[1]) + this._heartbeatDelayMargin;


### PR DESCRIPTION
add deltas for server and client heart-beat configuration

Example configuration:
stompit.connect({
    ........
    "heartbeatDelayMargin": 2500, // add wait delay for server beat interval
    "heartbeatOutputMargin": 500, // substract delay for client beat interval
    "connectHeaders": {
        ....
        "heart-beat": "5000,5000"
    }