### PR TITLE
Adding options to the incoming frame stream

### DIFF
--- a/lib/Socket.js
+++ b/lib/Socket.js
@@ -48,7 +48,7 @@ function Socket(transportSocket, options) {
     self.destroy(self.createTransportError(error));
   });
   
-  var incoming = new IncomingFrameStream();
+  var incoming = new IncomingFrameStream(options);
   
   this._incoming = incoming;
   transportSocket.pipe(incoming);


### PR DESCRIPTION
- The options passed by the client constructor never reached the IncomingFrameStream class. This prevented user overrides for maxLineLength an other parameters