### PR TITLE
Provide a callback option when explicitly ending a stream

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -185,10 +185,10 @@ Client.prototype.send = function(headers, options) {
 /*
  * Send a message with the specified body to the server.
  */
-Client.prototype.sendString = function(headers, body, options) {
+Client.prototype.sendString = function(headers, body, options, callback) {
   var frame = this.send(headers, options);
   frame.write(body);
-  frame.end();
+  frame.end(callback);
 };
 
 Client.prototype.begin = function(headers) {
@@ -259,14 +259,14 @@ Client.prototype._getAckHeaders = function(message, userHeaders) {
   });
 };
 
-Client.prototype.ack = function(message, headers, sendOptions) {
+Client.prototype.ack = function(message, headers, sendOptions, callback) {
   this.sendFrame('ACK', 
-    this._getAckHeaders(message, headers), sendOptions).end();
+    this._getAckHeaders(message, headers), sendOptions).end(callback);
 };
 
-Client.prototype.nack = function(message, headers, sendOptions) {
+Client.prototype.nack = function(message, headers, sendOptions, callback) {
   this.sendFrame('NACK', 
-    this._getAckHeaders(message, headers), sendOptions).end();
+    this._getAckHeaders(message, headers), sendOptions).end(callback);
 };
 
 Client.prototype.getSubscription = function(id) {

--- a/test/Client.ack.js
+++ b/test/Client.ack.js
@@ -42,6 +42,19 @@ describe('Client.ack', function() {
 
     done();
   });
+
+  it('should call the callback', function(done) {
+    client.ack({
+      headers: {
+        'subscription': '0',
+        'message-id': '001',
+        'ack': '002'
+      }
+    }, undefined, undefined, function() {
+      assert.ok(true);
+      done();
+    });
+  });
 });
 
 describe('Client.nack', function() {
@@ -81,5 +94,18 @@ describe('Client.nack', function() {
     assert(frame._finished);
 
     done();
+  });
+
+  it('should call the callback', function(done) {
+    client.nack({
+      headers: {
+        'subscription': '0',
+        'message-id': '001',
+        'ack': '002'
+      }
+    }, undefined, undefined, function() {
+      assert.ok(true);
+      done();
+    });
   });
 });

--- a/test/Client.js
+++ b/test/Client.js
@@ -232,6 +232,23 @@ describe('Client', function() {
                 client.sendString('/test', 'abcdefgh');
             });
         });
+
+        it('should call the callback', function(done) {
+            server._send = function(frame, beforeSendResponse) {
+                var writable = new BufferWritable(new Buffer(26));
+                frame.on('end', function() {
+                    beforeSendResponse();
+                });
+                frame.pipe(writable);
+            };
+
+            client.connect('localhost', function() {
+                client.sendString({destination: '/test'}, 'abcdefgh', undefined, function() {
+                  assert.ok(true);
+                  done();
+                });
+            });
+        });
     });
 
     describe('#destroy', function() {


### PR DESCRIPTION
ack, nack and sendString all do not allow for getting the writable
stream and therefore shall provide an ability to set a callback
function.

The use case for this is extremely helpful when you are attempting to prevent stack buildup of ack responses and also highly useful when you allow for a process to exit and want to validate that you have waited until everything has finished.  Right now, if you manually call the ack() your message may not be sent before the process is exited.