### PR TITLE
Expose client connection options

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -17,6 +17,8 @@ var ERROR_MAX_CONTENT_LENGTH = 4096;
 // STOMP client connection
 function Client(transportSocket, options) {
   
+  this._options = options;
+
   options = assign({
     commandHandlers: {},
     unknownCommand: onUnknownCommand,
@@ -360,6 +362,13 @@ Client.prototype.readEmptyBody = function(frame, callback) {
       self.destroy(this.createProtocolError('expected empty body frame'));
     }
   });
+};
+
+/*
+ * Get the connection options that the client was initialized with.
+ */
+Client.prototype.getOptions = function() {
+  return this._options;
 };
 
 function onConnected(frame, beforeSendResponse) {


### PR DESCRIPTION
It would be nice to expose the host/port that were used to initialize the client e.g. for logging which server we're now connected to after a reconnect event.