### PR TITLE
Expose ACK errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 docs/site
+.nyc_output

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -379,7 +379,7 @@ function frameHandler(frame, callback) {
       callback(err || new Error('The frame failed but no error was provided'));
     }
   };
-  frame.once('error', cb);
+  frame.on('error', cb);
   frame.end(function (err) {
     frame.removeListener('error', cb);
     if (typeof callback === 'function') {

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -16,7 +16,7 @@ var ERROR_MAX_CONTENT_LENGTH = 4096;
 
 // STOMP client connection
 function Client(transportSocket, options) {
-  
+
   this._options = options;
 
   options = assign({
@@ -24,18 +24,18 @@ function Client(transportSocket, options) {
     unknownCommand: onUnknownCommand,
     resetDisconnect: true
   }, options);
-  
+
   Socket.call(this, transportSocket, options);
-  
+
   this._receipts = {};
   this._nextReceiptId = 1;
-  
+
   this._subscriptions = {};
   this._nextSubcriptionId = 1;
-  
+
   this._nextTransactionId = 1;
-  
-  this._disconnecting = false;  
+
+  this._disconnecting = false;
   this._hasDisconnectReceipt = false;
 
   this._resetDisconnect = options.resetDisconnect === true;
@@ -48,11 +48,11 @@ Client.prototype._onInputEnd = function() {
     this.destroy();
   }
   else {
-    
-    var errorMessage = this.hasFinishedOutput() ? 
-      'connection ended without disconnect receipt' : 
+
+    var errorMessage = this.hasFinishedOutput() ?
+      'connection ended without disconnect receipt' :
       'connection ended unexpectedly';
-    
+
     this.destroy(this.createProtocolError(errorMessage));
   }
 };
@@ -77,36 +77,36 @@ Client.prototype._onDestroyed = function(exception) {
  * object for sending the frame body content.
  */
 Client.prototype.sendFrame = function(command, headers, options) {
-  
+
   if (options) {
-    
+
     var onReceipt = options.onReceipt;
-    
+
     if (typeof options.onError === 'function') {
-      
+
       var originalOnReceipt = onReceipt || function(){};
-      
+
       var onError = options.onError;
-      
+
       this.on('error', onError);
-      
+
       var self = this;
       onReceipt = function() {
         self.removeListener('error', onError);
         originalOnReceipt();
       };
     }
-    
+
     if (typeof onReceipt === 'function') {
-      
+
       var id = this._nextReceiptId++;
-      
+
       this._receipts[id] = onReceipt;
-      
+
       headers.receipt = id;
     }
   }
-  
+
   return Socket.prototype.sendFrame.apply(this, arguments);
 };
 
@@ -114,17 +114,17 @@ Client.prototype.sendFrame = function(command, headers, options) {
  * Send CONNECT frame to the server.
  */
 Client.prototype.connect = function(headers, callback) {
-  
+
   if (typeof headers === 'string') {
     headers = {'host': headers};
   }
-  
+
   headers = assign({
     'accept-version': '1.0,1.1,1.2'
   }, headers);
-  
+
   var heartbeat = this.getHeartbeat();
-  
+
   if (typeof headers['heart-beat'] === "string") {
     var match = headers['heart-beat'].match(/^(\d+) *, *(\d+)$/);
     if (match) {
@@ -132,42 +132,42 @@ Client.prototype.connect = function(headers, callback) {
       this.setHeartbeat(heartbeat);
     }
   }
-  
+
   headers['heart-beat'] = heartbeat[0] + "," + heartbeat[1];
-  
+
   this.setCommandHandlers({
     'CONNECTED': onConnected,
     'ERROR': onError
   });
-  
+
   if (typeof callback === 'function') {
-    
+
     var self = this;
-    
+
     (function() {
-      
+
       var onConnected = function(client) {
         cleanup();
         callback(null, client);
       };
-      
+
       var onError = function(error) {
         cleanup();
         callback(error);
       };
-      
+
       var cleanup = function() {
         self.removeListener('error', onError);
         self.removeListener('connect', onConnected);
       };
-      
+
       self.on('error', onError);
       self.on('connect', onConnected);
     })();
   }
-  
+
   var frame = this.sendFrame('CONNECT', headers);
-  
+
   frame.end();
 };
 
@@ -176,11 +176,11 @@ Client.prototype.connect = function(headers, callback) {
  * for sending the frame body content.
  */
 Client.prototype.send = function(headers, options) {
-  
+
   if (typeof headers === 'string') {
     headers = {destination: headers};
   }
-  
+
   return this.sendFrame('SEND', headers, options);
 };
 
@@ -194,7 +194,7 @@ Client.prototype.sendString = function(headers, body, options, callback) {
 };
 
 Client.prototype.begin = function(headers) {
-  
+
   if (typeof headers !== 'object') {
     if (typeof headers !== 'undefined') {
       headers = {transaction: headers};
@@ -203,53 +203,53 @@ Client.prototype.begin = function(headers) {
       headers = {};
     }
   }
-  
+
   if (!('transaction' in headers)) {
     headers.transaction = this._nextTransactionId++;
   }
-  
+
   var transaction = new Transaction(headers.transaction, this);
-  
+
   this.sendFrame('BEGIN', headers).end();
-  
+
   return transaction;
 };
 
 function ensureValidAckMode(mode) {
-  
+
   var validAckModes = [
     'auto', 'client', 'client-individual'
   ];
-  
+
   if (validAckModes.indexOf(mode) === -1) {
     throw new Error('invalid ack mode: \'' + mode + '\'');
   }
 }
 
 Client.prototype.subscribe = function(headers, messageListener) {
-  
+
   if (typeof headers === 'string') {
     headers = {destination: headers};
   }
-  
+
   var id = headers.id !== undefined ? headers.id : this._nextSubcriptionId++;
-  
+
   while (this._subscriptions[id] !== undefined) {
     id = this._nextSubcriptionId++;
   }
-  
+
   headers.id = id;
-  
+
   var ack = headers.ack || 'auto';
-  
+
   ensureValidAckMode(ack);
-  
+
   var subscription = new Subscription(id, ack, messageListener, this);
-  
+
   this._subscriptions[id] = subscription;
-  
+
   this.sendFrame('SUBSCRIBE', headers).end();
-  
+
   return subscription;
 };
 
@@ -262,13 +262,15 @@ Client.prototype._getAckHeaders = function(message, userHeaders) {
 };
 
 Client.prototype.ack = function(message, headers, sendOptions, callback) {
-  this.sendFrame('ACK', 
-    this._getAckHeaders(message, headers), sendOptions).end(callback);
+  var frame = this.sendFrame('ACK',
+    this._getAckHeaders(message, headers), sendOptions);
+  frameHandler(frame, callback);
 };
 
 Client.prototype.nack = function(message, headers, sendOptions, callback) {
-  this.sendFrame('NACK', 
-    this._getAckHeaders(message, headers), sendOptions).end(callback);
+  var frame = this.sendFrame('NACK',
+    this._getAckHeaders(message, headers), sendOptions);
+  frameHandler(frame, callback);
 };
 
 Client.prototype.getSubscription = function(id) {
@@ -276,22 +278,22 @@ Client.prototype.getSubscription = function(id) {
 };
 
 Client.prototype.setImplicitSubscription = function(id, ack, messageListener) {
-  
+
   if (this._subscriptions.hasOwnProperty(id)) {
     throw new Error('subscription id \'' + id + '\' already in use');
   }
-  
+
   if (ack === void 0 || ack === null){
     ack = 'auto';
   }
-  
+
   ensureValidAckMode(ack);
-  
+
   var subscription = new Subscription(id, ack, messageListener, this);
-  
+
   this._subscriptions[id] = subscription;
-  
-  return subscription; 
+
+  return subscription;
 };
 
 /*
@@ -299,39 +301,39 @@ Client.prototype.setImplicitSubscription = function(id, ack, messageListener) {
  * until all messages are acknowledged.
  */
 Client.prototype.disconnect = function(callback) {
-  
+
   var self = this;
-  
+
   if (typeof callback === 'function') {
     (function() {
-      
+
       var onEnd = function(client) {
         cleanup();
         callback(null, client);
       };
-      
+
       var onError = function(error) {
         cleanup();
         callback(error);
       };
-      
+
       var cleanup = function() {
         self.removeListener('end', onEnd);
         self.removeListener('error', onError);
       };
-      
+
       self.on('end', onEnd);
       self.on('error', onError);
     })();
   }
-  
+
   this.sendFrame('DISCONNECT', {}, {
     onReceipt: function() {
-      
+
       self._hasDisconnectReceipt = true;
-      
+
       var transport = self.getTransportSocket();
-      
+
       if (self._resetDisconnect) {
         this.destroy();
       }
@@ -340,19 +342,19 @@ Client.prototype.disconnect = function(callback) {
       }
     }
   }).end(this._finishOutput.bind(this));
-  
+
   // Keep the transport output open until the receipt is processed just in case
   // the transport is not configured to handle half-open connections.
-  
+
   this._disconnecting = true;
 };
 
 Client.prototype.readEmptyBody = function(frame, callback) {
-  
+
   var self = this;
-  
+
   frame.readEmptyBody(function(isEmpty) {
-    
+
     if (isEmpty) {
       if (typeof callback === 'function') {
         callback.call(self);
@@ -371,64 +373,79 @@ Client.prototype.getOptions = function() {
   return this._options;
 };
 
+function frameHandler(frame, callback) {
+  var cb = function (err) {
+    if (typeof callback === 'function') {
+      callback(err || new Error('The frame failed but no error was provided'));
+    }
+  };
+  frame.once('error', cb);
+  frame.end(function (err) {
+    frame.removeListener('error', cb);
+    if (typeof callback === 'function') {
+      callback(err);
+    }
+  });
+}
+
 function onConnected(frame, beforeSendResponse) {
-  
+
   // If no version header is present then assume the server is running stomp 1.0
   // protocol
   this.setVersion(frame.headers.version || '1.0');
-  
+
   this.setCommandHandlers({
     'MESSAGE': onMessage,
     'RECEIPT': onReceipt,
     'ERROR': onError
   });
-  
+
   var self = this;
-  
+
   this.readEmptyBody(frame, function() {
-    
+
     if (frame.headers['heart-beat'] !== undefined) {
-      
+
       var heartbeat = frame.headers['heart-beat']
         .split(',').map(function(x) {
           return parseInt(x, 10);
         });
-      
-      if ( heartbeat.length > 1 && 
-           !isNaN(heartbeat[0]) && 
+
+      if ( heartbeat.length > 1 &&
+           !isNaN(heartbeat[0]) &&
            !isNaN(heartbeat[1]) ) {
-        
+
         this._runHeartbeat(heartbeat[0], heartbeat[1]);
       }
     }
-    
+
     self.headers = frame.headers;
-    
+
     self.emit('connect', self);
-    
+
     beforeSendResponse();
   });
 }
 
 function onError(frame) {
-  
-  var message = frame.headers.message ? frame.headers.message : 
+
+  var message = frame.headers.message ? frame.headers.message :
     'server sent ERROR frame';
-  
+
   var error = this.createApplicationError(message);
-    
-  if ( frame.headers['content-type'] === 'text/plain' && 
+
+  if ( frame.headers['content-type'] === 'text/plain' &&
       frame.headers['content-length'] <= ERROR_MAX_CONTENT_LENGTH) {
-    
+
     var content = new BufferWritable(new Buffer(ERROR_MAX_CONTENT_LENGTH));
-    
+
     var self = this;
-    
+
     frame.on('end', function() {
       error.longMessage = content.getWrittenSlice().toString();
       self.destroy(error);
     });
-    
+
     frame.pipe(content);
   }
   else {
@@ -437,30 +454,30 @@ function onError(frame) {
 }
 
 function onMessage(frame, beforeSendResponse) {
-  
+
   var subId = frame.headers.subscription;
-  
+
   var subscription = this._subscriptions[subId];
-  
+
   if (subscription === void 0) {
     this.destroy(this.createProtocolError('invalid subscription id ' + subId));
     return;
   }
-  
+
   subscription.processMessageFrame(null, frame);
-  
+
   beforeSendResponse();
 }
 
 function onReceipt(frame, beforeSendResponse) {
-  
+
   var id = frame.headers['receipt-id'];
-  
+
   if (id === undefined || this._receipts[id] === undefined) {
     this.destroy(this.createProtocolError('invalid receipt'));
     return;
   }
-  
+
   this.readEmptyBody(frame, function() {
     this._receipts[id].call(this);
     delete this._receipts[id];

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "description": "STOMP client library for node.js",
   "version": "0.25.0",
   "keywords": [
-    "stomp", "messaging"
+    "stomp",
+    "messaging"
   ],
   "licenses": [
     {
@@ -12,21 +13,23 @@
     }
   ],
   "repository": {
-    "type":"git",
+    "type": "git",
     "url": "https://github.com/gdaws/node-stomp.git"
   },
-  "engines": { 
-    "node" : ">=0.10"
+  "engines": {
+    "node": ">=0.10"
   },
   "dependencies": {
     "qs": "~3.1.0",
     "object-assign": "^2.0.0"
   },
   "devDependencies": {
-    "mocha" : "^1.21.3",
-    "jshint": "^2.5.2"
+    "jshint": "^2.5.2",
+    "mocha": "^1.21.3",
+    "nyc": "^12.0.2"
   },
   "scripts": {
-    "test": "mocha --recursive && jshint ."
+    "test": "mocha --recursive && jshint .",
+    "coverage": "nyc npm t"
   }
 }

--- a/test/Client.ack.js
+++ b/test/Client.ack.js
@@ -6,7 +6,6 @@ var OutgoingFrameStreamFailing = require('./mock/OutgoingFrameStreamFailing');
 var assert = require('assert');
 
 describe('Client.ack', function() {
-  this.timeout(20000);
 
   var client, transport, framesOut, framesIn;
 

--- a/test/Client.ack.js
+++ b/test/Client.ack.js
@@ -2,9 +2,11 @@
 var Client = require('../index').Client;
 var Transport = require('./mock/Transport');
 var OutgoingFrameStream = require('./mock/OutgoingFrameStream');
+var OutgoingFrameStreamFailing = require('./mock/OutgoingFrameStreamFailing');
 var assert = require('assert');
 
 describe('Client.ack', function() {
+  this.timeout(20000);
 
   var client, transport, framesOut, framesIn;
 
@@ -52,6 +54,47 @@ describe('Client.ack', function() {
       }
     }, undefined, undefined, function() {
       assert.ok(true);
+      done();
+    });
+  });
+
+  it('should call the callback with an error', function(done) {
+    var errMsg = 'My Error Message';
+    var clientToFail = new Client(transport, {
+      outgoingFrameStream: new OutgoingFrameStreamFailing(errMsg)
+    });
+    clientToFail.ack({
+      headers: {
+        'subscription': '0',
+        'message-id': '001',
+        'ack': '002'
+      }
+    }, undefined, {
+      onError: function (err) {
+        assert.equal(err.message, errMsg);
+      }
+    }, function(err) {
+      assert.equal(err.message, errMsg);
+      done();
+    });
+  });
+
+  it('should call the callback with an undefined error', function(done) {
+    var clientToFail = new Client(transport, {
+      outgoingFrameStream: new OutgoingFrameStreamFailing()
+    });
+    clientToFail.ack({
+      headers: {
+        'subscription': '0',
+        'message-id': '001',
+        'ack': '002'
+      }
+    }, undefined, {
+      onError: function (err) {
+        assert.equal(err.message, 'The frame failed but no error was provided');
+      }
+    }, function(err) {
+      assert.equal(err.message, 'The frame failed but no error was provided');
       done();
     });
   });

--- a/test/mock/OutgoingFrameStreamFailing.js
+++ b/test/mock/OutgoingFrameStreamFailing.js
@@ -1,0 +1,77 @@
+var util    = require('util');
+var Stream  = require('stream');
+
+function OutgoingFrameStream(errMsg) {
+  this._errMsg = errMsg;
+  this._version = null;
+  this._finished = false;
+  this._frame = null;
+}
+
+OutgoingFrameStream.prototype.setVersion = function(value) {
+  this.value = value;
+};
+
+OutgoingFrameStream.prototype.frame = function(command, headers, streamOptions) {
+  var frame = new Frame(this, command, headers, streamOptions, this._errMsg);
+  this._frame = frame;
+  return frame;
+};
+
+OutgoingFrameStream.prototype.finish = function() {
+  this._finished = true;
+};
+
+OutgoingFrameStream.prototype.hasFinished = function() {
+  return this._finished;
+};
+
+function Frame(stream, command, headers, streamOptions, errMsg) {
+
+  Stream.Writable.call(this, streamOptions);
+
+  this.command = command;
+  this.headers = headers;
+  this._stream = stream;
+  this._errMsg = errMsg;
+
+  this._body = new Buffer(0);
+
+  this._finished = false;
+
+  var self = this;
+
+  this.once('finish', function() {
+    self._finished = true;
+  });
+}
+
+Frame.prototype._write = function() {
+  this.emit('error', this._errMsg ? new Error(this._errMsg) : null);
+};
+
+Frame.prototype.end = function(cb) {
+  this._endFrame(cb);
+};
+
+Frame.prototype._endFrame = function(cb) {
+  var self = this;
+
+  this.write('\x00\n', 'utf-8', function(error) {
+
+    if (cb) {
+      cb(error);
+    }
+
+    Stream.Writable.prototype.end.apply(self);
+  });
+};
+
+util.inherits(Frame, Stream.Writable);
+
+OutgoingFrameStream.prototype._write = function(chunk, encoding, callback) {
+  this._body = Buffer.concat([this._body, chunk]);
+  callback();
+};
+
+module.exports = OutgoingFrameStream;

--- a/test/mock/OutgoingFrameStreamFailing.js
+++ b/test/mock/OutgoingFrameStreamFailing.js
@@ -46,6 +46,8 @@ function Frame(stream, command, headers, streamOptions, errMsg) {
   });
 }
 
+util.inherits(Frame, Stream.Writable);
+
 Frame.prototype._write = function() {
   this.emit('error', this._errMsg ? new Error(this._errMsg) : null);
 };
@@ -66,8 +68,6 @@ Frame.prototype._endFrame = function(cb) {
     Stream.Writable.prototype.end.apply(self);
   });
 };
-
-util.inherits(Frame, Stream.Writable);
 
 OutgoingFrameStream.prototype._write = function(chunk, encoding, callback) {
   this._body = Buffer.concat([this._body, chunk]);


### PR DESCRIPTION
I've suffered an issue while using this library where I called the `client.ack` method with a callback and I was getting no errors inside that callback (I have tested it and proved I was getting some errors in other scenarios).

The specific ACK error I wasn't getting the error is when AMQ couldn't set the message as ACK'd because of this error:
```
2018-06-19 21:30:26,184 | WARN  | Exception occurred processing: ACK -> org.apache.activemq.transport.stomp.ProtocolException: Unexpected ACK received for message-id [ID:2f6aae2a73a0-35867-1529354627350-1:291238:1:1:10] | ActiveMQ NIO Worker 3
```

I can see that error is caught and it's destroying the socket in line https://github.com/gdaws/node-stomp/blob/master/lib/Socket.js#L182, so I could see then the following logs in my AMQ server:
```
2018-06-19 21:30:26,370 | WARN  | Transport Connection to: tcp://XX.XX.XX.XX:49494 failed: javax.net.ssl.SSLException: Inbound closed before receiving peer's close_notify: possible truncation attack? | ActiveMQ NIO Worker 4
```

But that error is not exposed upwards, so client.ack resolves as if it was successful. These proposed changes try to expose that error, forwarding it to the callback function.

Feel free to edit it if you think it should be handled in any other way.